### PR TITLE
Fixed: Root of user's Cloud can be as root directory for OPDS

### DIFF
--- a/files_opds/ajax/personal.php
+++ b/files_opds/ajax/personal.php
@@ -23,27 +23,27 @@ $fileTypes = isset($_POST['fileTypes']) ? $_POST['fileTypes'] : '';
 $skipList = isset($_POST['skipList']) ? $_POST['skipList'] : 'metadata.opf,cover.jpg';
 $feedTitle = isset($_POST['feedTitle']) ? $_POST['feedTitle'] : $l->t("%s's Library", \OCP\User::getDisplayName());
 
-if (!is_null($rootPath)){
-        if (\OC\Files\Filesystem::file_exists($rootPath) === false ){
-		\OCP\JSON::error(
-			array(
-				'data' => array('message'=> $l->t('Directory does not exist!'))
-			)
-		);
-        } else {
-        	Config::set('root_path', $rootPath);
-        	\OCP\JSON::success(
-                array(
-                        'data' => array('message'=> $l->t('Settings updated successfully.'))
-                        )
-        	);
-	}
+if (!strlen($rootPath) ||
+    \OC\Files\Filesystem::isValidPath($rootPath) === false || 
+    \OC\Files\Filesystem::file_exists($rootPath) === false ) {
+	\OCP\JSON::error(
+		array(
+			'data' => array('message'=> $l->t('Directory does not exist!'))
+		)
+	);
+} else {
+	Config::set('root_path', $rootPath);
         Config::set('enable', $opdsEnable);
         Config::set('file_types', $fileTypes);
         Config::set('skip_list', $skipList);
         Config::set('feed_title', $feedTitle);
 	Config::set('id', Util::genUuid());
-        exit();
+
+       	\OCP\JSON::success(
+	array(
+		'data' => array('message'=> $l->t('Settings updated successfully.'))
+		)
+	);
 }
 
 exit();

--- a/files_opds/lib/files.php
+++ b/files_opds/lib/files.php
@@ -69,6 +69,14 @@ class Files extends \OCA\Files\Helper
 	 * @return bool true if $child is a subdirectory of $parent
 	 */
 	public static function isChild($parent, $child) {
-		return strpos($child, $parent . '/') === 0;
+
+		if ($parent[0] !== '/') {
+			$parent = '/' . $parent;
+		}
+		if (strlen($parent) > 1 && substr($parent, -1) !== '/') {
+			$parent .= '/';
+		}
+
+		return (strpos($child, $parent) === 0 && strcmp($child, $parent) !== 0);
 	}
 }


### PR DESCRIPTION
Two fixes:
- Now set value "/" for Root directory in personal settings is possible without problem;
- Additional checks for value "" (empty, but not NULL).