### PR TITLE
Undefined method at feed.php

### DIFF
--- a/files_opds/lib/feed.php
+++ b/files_opds/lib/feed.php
@@ -115,7 +115,7 @@ class Feed
 				. $scheme
 				. "://"
 				. $_SERVER['HTTP_HOST']
-				. \OC_Helper::mimetypeIcon($i->getMimeType())
+				. \OC::$server->getMimeTypeDetector()->mimeTypeIcon($i->getMimeType())
 				);
 			/* Note: relative URL should be enough (RFC7231) but some OPDS clients
 			 * (especially those in dedicated book readers) might not support them

--- a/files_opds/lib/feed.php
+++ b/files_opds/lib/feed.php
@@ -120,7 +120,7 @@ class Feed
 			/* Note: relative URL should be enough (RFC7231) but some OPDS clients
 			 * (especially those in dedicated book readers) might not support them
 			 * 
-			 * header("Location: " . \OC_Helper::mimetypeIcon($i->getMimeType()));
+			 * header("Location: " . \OC::$server->getMimeTypeDetector()->mimeTypeIcon($i->getMimeType()));
 			 */
 		}
         }


### PR DESCRIPTION
From logs:
`[...] Call to undefined method OC_Helper::mimetypeIcon() at \/opt\/www\/apps\/files_opds\/lib\/feed.php#118 [...] "method":"GET","url":"\/apps\/files_opds\/?tid=725"
`

As I found, OC_Helper::mimetypeIcon() is deprecated since 8.0.0. See also https://github.com/owncloud/core/issues/17421