### PR TITLE
Fix deprecated calls in files_reader app

### DIFF
--- a/files_reader/lib/Hooks.php
+++ b/files_reader/lib/Hooks.php
@@ -38,9 +38,9 @@ class Hooks {
         // TODO: rmeove this when Owncloud starts encoding oc_appconfig as JSON just like it already encodes most other properties
         $isJson = self::isJson($settings['array']['oc_appconfig']);
         $array = ($isJson) ? json_decode($settings['array']['oc_appconfig'], true) : $settings['array']['oc_appconfig'];
-        $array['filesReader']['enableEpub'] = Config::get('epub_enable', 'true');
-        $array['filesReader']['enablePdf'] = Config::get('pdf_enable', 'true');
-        $array['filesReader']['enableCbx'] = Config::get('cbx_enable', 'true');
+        $array['filesReader']['enableEpub'] = \OC::$server->getConfig()->getAppValue('epub_enable', 'true');
+        $array['filesReader']['enablePdf'] = \OC::$server->getConfig()->getAppValue('pdf_enable', 'true');
+        $array['filesReader']['enableCbx'] = \OC::$server->getConfig()->getAppValue('cbx_enable', 'true');
         $settings['array']['oc_appconfig'] = ($isJson) ? json_encode($array) : $array;
     }
 


### PR DESCRIPTION
Hello,

I fixed up the deprecated OCP\JSON and OCP\Config calls for Nextcloud 14+.