### PR TITLE
Update owncloud version files_reader

### DIFF
--- a/files_reader/appinfo/info.xml
+++ b/files_reader/appinfo/info.xml
@@ -42,7 +42,7 @@ See [README] for more exhaustive information on features and potential misfeatur
     <screenshot>https://raw.githubusercontent.com/Yetangitu/owncloud-apps/master/screenshots/files_reader-3.png</screenshot>
     <screenshot>https://raw.githubusercontent.com/Yetangitu/owncloud-apps/master/screenshots/files_reader_PDF_005.png</screenshot>
     <screenshot>https://raw.githubusercontent.com/Yetangitu/owncloud-apps/master/screenshots/files_reader_PDF_006.png</screenshot>
-	<screenshot>https://raw.githubusercontent.com/Yetangitu/owncloud-apps/master/screenshots/photo_2017-03-15_17-22-00.jpg</screenshot>
+    <screenshot>https://raw.githubusercontent.com/Yetangitu/owncloud-apps/master/screenshots/photo_2017-03-15_17-22-00.jpg</screenshot>
     <screenshot>https://raw.githubusercontent.com/Yetangitu/owncloud-apps/master/screenshots/photo_2017-03-15_17-22-02.jpg</screenshot>
     <category>files</category>
     <category>multimedia</category>
@@ -51,11 +51,11 @@ See [README] for more exhaustive information on features and potential misfeatur
         <filesystem/>
     </types>
     <dependencies>
-        <owncloud min-version="8.2" max-version="10.0" />
+        <owncloud min-version="8.2" max-version="10"/>
         <nextcloud min-version="8.1" max-version="13.0"/>
-		<database>pgsql</database>
-		<database>sqlite</database>
-		<database>mysql</database>
+        <database>pgsql</database>
+        <database>sqlite</database>
+        <database>mysql</database>
     </dependencies>
     <ocsid>167127</ocsid>
 </info>


### PR DESCRIPTION
> App developers should re-release their apps after setting the “max-version” field to “10” instead of “10.0” in “appinfo/info.xml”, and increase the app’s version as well
to make sure ownCloud picks up the change. This is required because else ownCloud 10.1 will think that the apps are not compatible any more and will refuse to update or enable them.

https://central.owncloud.org/t/owncloud-core-switching-to-semver-apps-need-re-release/17054

Fixes #115