### PR TITLE
Update owncloud version files_opds

### DIFF
--- a/files_opds/appinfo/info.xml
+++ b/files_opds/appinfo/info.xml
@@ -36,7 +36,7 @@ See [README] for more information on (mis)features of this app.
             <database>pgsql</database>
             <database>sqlite</database>
             <database>mysql</database>
-            <owncloud min-version="8.2" max-version="10.0" />
+            <owncloud min-version="8.2" max-version="10" />
             <nextcloud min-version="8.1" max-version="13.0" />
         </dependencies>
 	<settings>


### PR DESCRIPTION
> App developers should re-release their apps after setting the “max-version” field to “10” instead of “10.0” in “appinfo/info.xml”, and increase the app’s version as well
to make sure ownCloud picks up the change. This is required because else ownCloud 10.1 will think that the apps are not compatible any more and will refuse to update or enable them.

https://central.owncloud.org/t/owncloud-core-switching-to-semver-apps-need-re-release/17054

Fixes #115